### PR TITLE
Remove geb from the rest-api profile

### DIFF
--- a/profile.yml
+++ b/profile.yml
@@ -3,7 +3,6 @@ features:
     defaults: 
         - hibernate5
         - events
-        - geb
     required:
         - json-views
 build:


### PR DESCRIPTION
I don't think it make sense to include Geb for the rest-api profile. Grails 4 can be a great moment to remove this feature of the rest-api profile. 