### PR TITLE
spring security 5/ spring security core upgrade

### DIFF
--- a/features/security/feature.yml
+++ b/features/security/feature.yml
@@ -1,4 +1,5 @@
 description: Adds Spring Security REST to the project
 dependencies:
     compile:
-        - org.grails.plugins:spring-security-rest:2.0.0.RC1
+        - "org.grails.plugins:spring-security-rest:2.0.0.RC1"
+        - "org.grails.plugins:spring-security-core:4.0.0.M1"

--- a/features/security/skeleton/grails-app/conf/application.groovy
+++ b/features/security/skeleton/grails-app/conf/application.groovy
@@ -11,3 +11,4 @@ grails.plugin.springsecurity.filterChain.chainMap = [
                 filters: 'JOINED_FILTERS,-restTokenValidationFilter,-restExceptionTranslationFilter'
         ]
 ]
+grails.plugin.springsecurity.rest.token.storage.jwt.secret = "changemechangemechangemechangeme"

--- a/features/security/skeleton/grails-app/conf/spring/resources.groovy
+++ b/features/security/skeleton/grails-app/conf/spring/resources.groovy
@@ -1,0 +1,62 @@
+import grails.plugin.springsecurity.BeanTypeResolver
+import grails.plugin.springsecurity.SpringSecurityUtils
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.DelegatingPasswordEncoder
+import org.springframework.security.crypto.password.LdapShaPasswordEncoder
+import org.springframework.security.crypto.password.Md4PasswordEncoder
+import org.springframework.security.crypto.password.MessageDigestPasswordEncoder
+import org.springframework.security.crypto.password.NoOpPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder
+import org.springframework.security.crypto.password.StandardPasswordEncoder
+import org.springframework.security.crypto.scrypt.SCryptPasswordEncoder
+import grails.plugin.springsecurity.BeanTypeResolver
+
+
+beans = {
+    /** passwordEncoder */
+    def conf = SpringSecurityUtils.securityConfig
+    String algorithm = conf.password.algorithm
+    Class beanTypeResolverClass = conf.beanTypeResolverClass ?: BeanTypeResolver
+    def beanTypeResolver = beanTypeResolverClass.newInstance(conf, application)
+
+    passwordEncoder(beanTypeResolver.resolveType('passwordEncoder', DelegatingPasswordEncoder), algorithm, idToPasswordEncoder(conf))
+}
+
+
+Map<String, PasswordEncoder> idToPasswordEncoder(ConfigObject conf) {
+
+    final String ENCODING_ID_BCRYPT = "bcrypt"
+    final String ENCODING_ID_LDAP = "ldap"
+    final String ENCODING_ID_MD4 = "MD4"
+    final String ENCODING_ID_MD5 = "MD5"
+    final String ENCODING_ID_NOOP = "noop"
+    final String ENCODING_ID_PBKDF2 = "pbkdf2"
+    final String ENCODING_ID_SCRYPT = "scrypt"
+    final String ENCODING_ID_SHA1 = "SHA-1"
+    final String ENCODING_IDSHA256 = "SHA-256"
+
+    MessageDigestPasswordEncoder messageDigestPasswordEncoderMD5 = new MessageDigestPasswordEncoder(ENCODING_ID_MD5)
+    messageDigestPasswordEncoderMD5.encodeHashAsBase64 = conf.password.encodeHashAsBase64 // false
+    messageDigestPasswordEncoderMD5.iterations = conf.password.hash.iterations // 10000
+
+    MessageDigestPasswordEncoder messsageDigestPasswordEncoderSHA1 = new MessageDigestPasswordEncoder(ENCODING_ID_SHA1)
+    messsageDigestPasswordEncoderSHA1.encodeHashAsBase64 = conf.password.encodeHashAsBase64 // false
+    messsageDigestPasswordEncoderSHA1.iterations = conf.password.hash.iterations // 10000
+
+    MessageDigestPasswordEncoder messsageDigestPasswordEncoderSHA256 = new MessageDigestPasswordEncoder(ENCODING_IDSHA256)
+    messsageDigestPasswordEncoderSHA256.encodeHashAsBase64 = conf.password.encodeHashAsBase64 // false
+    messsageDigestPasswordEncoderSHA256.iterations = conf.password.hash.iterations // 10000
+
+    int strength = conf.password.bcrypt.logrounds
+    [(ENCODING_ID_BCRYPT): new BCryptPasswordEncoder(strength),
+     (ENCODING_ID_LDAP): new LdapShaPasswordEncoder(),
+     (ENCODING_ID_MD4): new Md4PasswordEncoder(),
+     (ENCODING_ID_MD5): messageDigestPasswordEncoderMD5,
+     (ENCODING_ID_NOOP): NoOpPasswordEncoder.getInstance(),
+     (ENCODING_ID_PBKDF2): new Pbkdf2PasswordEncoder(),
+     (ENCODING_ID_SCRYPT): new SCryptPasswordEncoder(),
+     (ENCODING_ID_SHA1): messsageDigestPasswordEncoderSHA1,
+     (ENCODING_IDSHA256): messsageDigestPasswordEncoderSHA256,
+     "sha256": new StandardPasswordEncoder()]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 baseProfileVersion=4.0.0.RC1
-grailsVersion=4.0.0.BUILD-SNAPSHOT
+grailsVersion=3.3.2

--- a/rest-api.iml
+++ b/rest-api.iml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id="rest-api" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="org.grails.profiles" external.system.module.version="4.0.0.BUILD-SNAPSHOT" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="groovy-2.5.6" level="application" />
+  </component>
+</module>


### PR DESCRIPTION
This pr adds config for passwordEncoder that the Grails 4 / Spring Security 5 version of the grails-spring-security-core plugin uses. Without it the apps generated for Grails 4 do not start properly when created with security feature from the cli.