### PR TITLE
Fixes java.net.MalformedURLException in default generated FunctionalSpec

### DIFF
--- a/templates/testing/Functional.groovy
+++ b/templates/testing/Functional.groovy
@@ -21,7 +21,7 @@ class @artifact.name@Spec extends Specification {
 
     @OnceBefore
     void init() {
-        String baseUrl = "http://localhost:\$serverPort"
+        String baseUrl = "http://localhost:$serverPort"
         this.client  = HttpClient.create(new URL(baseUrl))
     }
 


### PR DESCRIPTION
This is due to escaping of `$` in the serverPort.

See https://travis-ci.org/grails-profiles-tests/rest-api/builds/652900066